### PR TITLE
Make unit tests work on embedded and native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,8 +24,11 @@ framework = spl
 debug_tool = cmsis-dap
 test_ignore = test_native
 
-
 [env:gd32350g_start]
 board = gd32350g_start
 framework = spl
 test_ignore = test_native
+; hint: If a test fails, you can redirect the "PIO Debug" debug task
+; to instead start debugging the test firmware.
+; https://docs.platformio.org/en/latest/projectconf/sections/env/options/debug/debug_test.html
+; debug_test = test_common

--- a/test/test_common/unity_config.c
+++ b/test/test_common/unity_config.c
@@ -1,0 +1,22 @@
+#include "unity_config.h"
+#include <stdio.h>
+/* 
+ * test_common tests are executed by both native + embedded targets
+ * for the embedded targets we are forced to have unity_config.c in this folder.
+ * however, that would then also be used on the native target.
+ * So, we have to conditionally provide the native or embedded code here.
+ * For simplicity, we use the global "GD32F3x0" macro that will be present
+ * when compiling for our embedded targets. Otherwise, we could also check
+ * some built-in macros like __ARM_EABI__, __ARM_ARCH_7M__, etc.
+ */
+#ifdef GD32F3x0
+/* to avoid code duplication: let's use the same .c file as in the embedded folder already. */
+/* a bit hacky and makes us dependent on test_embedded existing. Copy-paste code if needed. */
+#include "../test_embedded/unity_config.c"
+#else
+/* for platform = native */
+void unityOutputStart(unsigned long baudrate) { }
+void unityOutputChar(char c) { putchar(c); }
+void unityOutputFlush(void) { fflush(stdout); }
+void unityOutputComplete(void) { }
+#endif

--- a/test/test_common/unity_config.h
+++ b/test/test_common/unity_config.h
@@ -1,0 +1,32 @@
+
+#ifndef UNITY_CONFIG_H
+#define UNITY_CONFIG_H
+
+#ifndef NULL
+#ifndef __cplusplus
+#define NULL (void*)0
+#else
+#define NULL 0
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void unityOutputStart();
+void unityOutputChar(char);
+void unityOutputFlush();
+void unityOutputComplete();
+
+#define UNITY_OUTPUT_START()    unityOutputStart()
+#define UNITY_OUTPUT_CHAR(c)    unityOutputChar((char)c)
+#define UNITY_OUTPUT_FLUSH()    unityOutputFlush()
+#define UNITY_OUTPUT_COMPLETE() unityOutputComplete()
+
+#ifdef __cplusplus
+}
+#endif /* extern "C" */
+
+#endif /* UNITY_CONFIG_H */

--- a/test/test_embedded/unity_config.h
+++ b/test/test_embedded/unity_config.h
@@ -21,7 +21,7 @@ void unityOutputFlush();
 void unityOutputComplete();
 
 #define UNITY_OUTPUT_START()    unityOutputStart()
-#define UNITY_OUTPUT_CHAR(c)    unityOutputChar(c)
+#define UNITY_OUTPUT_CHAR(c)    unityOutputChar((char)c)
 #define UNITY_OUTPUT_FLUSH()    unityOutputFlush()
 #define UNITY_OUTPUT_COMPLETE() unityOutputComplete()
 


### PR DESCRIPTION
* corrects unity_config.c implementation in regards to UART sending 
  * was missing waiting for transmission buffer empty
  * UART_AFs were not set
* adds startup delay in embedded firmware using SysTick so that there's no need to push the reset button
* de-duplicates the embedded unity config code by including the embedded code in tests_common if the embedded target is detected
* adds hints to `platformio.ini`

![grafik](https://user-images.githubusercontent.com/26485477/234954847-77736df8-ca06-4473-8835-41ed1017b4f7.png)
